### PR TITLE
Fix issue with TypeError: metricInterval.clearInterval is not a function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '14'
   - '6'
   - '4'
 script:

--- a/README.md
+++ b/README.md
@@ -45,12 +45,15 @@ started.stop();
 Initialize
 
 options:
-- promClient (*optional*): prom client instance
-- interval (*optional*, default 60000): interval in ms to fetch the Bull statistic
+- `promClient` (*optional*): prom client instance
+- `interval` (*optional*, default 60000): interval in ms to fetch the Bull statistic
 
 ### start(queue)
 Start running and fetching the data from Bull based on interval with the given Bull queue.
-Returns a optional function `stop()` which will stop monitoring of the queue if called.
+
+Returns a queue metrics object which includes the following methods:
+- `stop()`: stops monitoring the queue metrics
+- `remove()`: removes metrics from prometheus
 
 ## Contributors
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,10 +1,12 @@
+import client = require('prom-client');
 import * as bull from 'bull';
 export interface Options {
-    promClient?: any;
+    promClient?: typeof client;
     interval?: number;
 }
 export declare function init(opts: Options): {
     start: (queue: bull.Queue) => {
-        stop: () => any;
+        stop: () => void;
+        remove: () => void;
     };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,6 @@ function init(opts) {
         ageBuckets: 13,
     });
     function start(queue) {
-        let metricInterval;
         const keyPrefix = queue.keyPrefix.replace(/.*\{|\}/gi, '');
         const labels = {
             [QUEUE_NAME_LABEL]: queue.name,
@@ -58,7 +57,7 @@ function init(opts) {
             const duration = job.finishedOn - job.processedOn;
             durationMetric.observe(labels, duration);
         });
-        metricInterval = setInterval(() => {
+        const metricInterval = setInterval(() => {
             queue
                 .getJobCounts()
                 .then(({ completed, failed, delayed, active, waiting }) => {
@@ -69,8 +68,17 @@ function init(opts) {
                 waitingMetric.set(labels, (waiting || 0));
             });
         }, interval);
+        const removeMetrics = () => {
+            durationMetric.remove(labels);
+            completedMetric.remove(labels);
+            failedMetric.remove(labels);
+            delayedMetric.remove(labels);
+            activeMetric.remove(labels);
+            waitingMetric.remove(labels);
+        };
         return {
-            stop: () => metricInterval.clearInterval(),
+            stop: () => clearInterval(metricInterval),
+            remove: removeMetrics
         };
     }
     return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bull-prom",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Provide prometheus metrics for Bull",
   "license": "MIT",
   "repository": "https://github.com/pbadenski/bull-prom",
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "bull": ">=3",
-    "prom-client": ">=12"
+    "prom-client": ">=13.1.0"
   },
   "devDependencies": {
     "@types/bull": "^3.13.0",
@@ -41,7 +41,7 @@
     "coveralls": "^3.1.0",
     "mocha": "^7.2.0",
     "nyc": "^15.0.1",
-    "prom-client": "^12.0.0",
+    "prom-client": "^13.1.0",
     "rimraf": "^3.0.2",
     "sinon": "^9.0.2",
     "ts-node": "^8.10.1",


### PR DESCRIPTION
I noticed that calls to `stop()` were resulting in errors like this:

```
(node:27721) UnhandledPromiseRejectionWarning: TypeError: metricInterval.clearInterval is not a function
    at Object.stop (****/bull-exporter/node_modules/bull-prom/lib/index.js:73:40)
    ...
```

Looking at the documentation it looks `clearInterval` should actually be called with the `NodeJS.Timeout` created by the call to `setInterval()`. This fix should get rid of that error.

I made a couple other minor updates:
- Update `metricInterval` to a `const`
- Add node 14 to travis config (not sure if this is still being used)
- Update promClient type from `any` to the `promClient` type
- Bump this to version `3.1.0`
- Add `remove()` function to queue metrics to allow removing all queue specific metrics from prometheus. Requires updating prom-client to `13.1.0` or later because of https://github.com/siimon/prom-client/commit/3a86d05c49addc8294e9dcf16600226d6b970385