### PR TITLE
feat: additional metrics, support for global events

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Provides [Prometheus](https://prometheus.io/) metrics for [Bull](https://github.
 | jobs_failed_total            | counter | Total number of failed jobs                             |
 | jobs_waiting_total           | counter | Total number of jobs waiting to be processed            |
 
+_IMPORTANT_: If you are using this library to track job duration metrics for a queue for multiple consumers you will need to listen to the `global:completed` event. Otherwise this library will not record job duration metrics. To listen to this event instead of the `completed` event you'll need to set the init paremeter `useGlobal` to true.
+
 ## Usage
 ```typescript
 import Queue from 'bull';
@@ -25,6 +27,7 @@ const queue = new Queue('myQueue'...);
 const bullMetric = bullProm.init({
   promClient, // optional, it will use internal prom client if it is not given
   interval: 1000, // optional, in ms, default to 60000
+  useGlobal: false, // optional, default to false
 });
 
 const started = bullMetric.start(queue);
@@ -46,7 +49,8 @@ Initialize
 
 options:
 - `promClient` (*optional*): prom client instance
-- `interval` (*optional*, default 60000): interval in ms to fetch the Bull statistic
+- `interval` (*optional*, default `60000`): interval in ms to fetch the Bull statistic
+- `useGlobal` (*optional*, default `false`)
 
 ### start(queue)
 Start running and fetching the data from Bull based on interval with the given Bull queue.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@ Provides [Prometheus](https://prometheus.io/) metrics for [Bull](https://github.
 
 ## Metrics
 
-| Metric                       | type    | description                                             |
-|------------------------------|---------|---------------------------------------------------------|
-| jobs_completed_total         | counter | Total number of completed jobs                          |
-| jobs_duration_milliseconds   | summary | Processing time for completed jobs                      |
-| jobs_active_total            | counter | Total number of active jobs (currently being processed) |
-| jobs_delayed_total           | counter | Total number of jobs that will run in the future        |
-| jobs_failed_total            | counter | Total number of failed jobs                             |
-| jobs_waiting_total           | counter | Total number of jobs waiting to be processed            |
+| Metric                              | type    | description                                             |
+|-------------------------------------|---------|---------------------------------------------------------|
+| jobs_completed_total                | counter | Total number of completed jobs                          |
+| jobs_active_total                   | counter | Total number of active jobs (currently being processed) |
+| jobs_delayed_total                  | counter | Total number of jobs that will run in the future        |
+| jobs_failed_total                   | counter | Total number of failed jobs                             |
+| jobs_waiting_total                  | counter | Total number of jobs waiting to be processed            |
+| jobs_duration_milliseconds          | summary | Processing time for completed/failed                    |
+| jobs_waiting_duration_milliseconds  | summary | Waiting time for completed/failed                       |
+| jobs_attempts                       | summary | Processing time for completed/failed/jobs               |
 
 _IMPORTANT_: If you are using this library to track job duration metrics for a queue for multiple consumers you will need to listen to the `global:completed` event. Otherwise this library will not record job duration metrics. To listen to this event instead of the `completed` event you'll need to set the init paremeter `useGlobal` to true.
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,6 +5,10 @@ export interface Options {
     interval?: number;
     useGlobal?: boolean;
 }
+export declare enum JobStatus {
+    COMPLETED = "completed",
+    FAILED = "failed"
+}
 export declare function init(opts: Options): {
     start: (queue: bull.Queue) => {
         stop: () => void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,6 +3,7 @@ import * as bull from 'bull';
 export interface Options {
     promClient?: typeof client;
     interval?: number;
+    useGlobal?: boolean;
 }
 export declare function init(opts: Options): {
     start: (queue: bull.Queue) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,18 +9,26 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.init = void 0;
+exports.init = exports.JobStatus = void 0;
 const client = require("prom-client");
+var JobStatus;
+(function (JobStatus) {
+    JobStatus["COMPLETED"] = "completed";
+    JobStatus["FAILED"] = "failed";
+})(JobStatus = exports.JobStatus || (exports.JobStatus = {}));
 function init(opts) {
     const { interval = 60000, promClient = client, useGlobal = false } = opts;
     const QUEUE_NAME_LABEL = 'queue_name';
     const QUEUE_PREFIX_LABEL = 'queue_prefix';
+    const STATUS_LABEL = 'status';
     const activeMetricName = 'jobs_active_total';
     const waitingMetricName = 'jobs_waiting_total';
     const completedMetricName = 'jobs_completed_total';
     const failedMetricName = 'jobs_failed_total';
     const delayedMetricName = 'jobs_delayed_total';
     const durationMetricName = 'jobs_duration_milliseconds';
+    const waitingDurationMetricName = 'jobs_waiting_duration_milliseconds';
+    const attemptsMadeMetricName = 'jobs_attempts';
     const completedMetric = new promClient.Gauge({
         name: completedMetricName,
         help: 'Number of completed jobs',
@@ -49,10 +57,35 @@ function init(opts) {
     const durationMetric = new promClient.Summary({
         name: durationMetricName,
         help: 'Time to complete jobs',
-        labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL],
+        labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL, STATUS_LABEL],
         maxAgeSeconds: 300,
         ageBuckets: 13,
     });
+    const waitingDurationMetric = new promClient.Summary({
+        name: waitingDurationMetricName,
+        help: 'Time spent waiting for a job to run',
+        labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL, STATUS_LABEL],
+        maxAgeSeconds: 300,
+        ageBuckets: 13
+    });
+    const attemptsMadeMetric = new promClient.Summary({
+        name: attemptsMadeMetricName,
+        help: 'Job attempts made',
+        labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL, STATUS_LABEL],
+        maxAgeSeconds: 300,
+        ageBuckets: 13
+    });
+    function recordJobMetrics(labels, status, job) {
+        if (!job.finishedOn) {
+            return;
+        }
+        const jobLabels = Object.assign({ [STATUS_LABEL]: status }, labels);
+        const jobDuration = job.finishedOn - job.processedOn;
+        durationMetric.observe(jobLabels, jobDuration);
+        const waitingDuration = job.processedOn - job.timestamp;
+        waitingDurationMetric.observe(jobLabels, waitingDuration);
+        attemptsMadeMetric.observe(jobLabels, job.attemptsMade);
+    }
     function start(queue) {
         const keyPrefix = queue.keyPrefix.replace(/.*\{|\}/gi, '');
         const labels = {
@@ -62,20 +95,19 @@ function init(opts) {
         if (useGlobal) {
             queue.on('global:completed', (jobId) => __awaiter(this, void 0, void 0, function* () {
                 const job = yield queue.getJob(jobId);
-                if (!job.finishedOn) {
-                    return;
-                }
-                const duration = job.finishedOn - job.processedOn;
-                durationMetric.observe(labels, duration);
+                recordJobMetrics(labels, JobStatus.COMPLETED, job);
+            }));
+            queue.on('global:failed', (jobId) => __awaiter(this, void 0, void 0, function* () {
+                const job = yield queue.getJob(jobId);
+                recordJobMetrics(labels, JobStatus.FAILED, job);
             }));
         }
         else {
             queue.on('completed', (job) => {
-                if (!job.finishedOn) {
-                    return;
-                }
-                const duration = job.finishedOn - job.processedOn;
-                durationMetric.observe(labels, duration);
+                recordJobMetrics(labels, JobStatus.COMPLETED, job);
+            });
+            queue.on('failed', (job) => {
+                recordJobMetrics(labels, JobStatus.FAILED, job);
             });
         }
         const metricInterval = setInterval(() => {
@@ -96,6 +128,8 @@ function init(opts) {
             delayedMetric.remove(labels);
             activeMetric.remove(labels);
             waitingMetric.remove(labels);
+            waitingDurationMetric.remove(labels);
+            attemptsMadeMetric.remove(labels);
         };
         return {
             stop: () => clearInterval(metricInterval),

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,18 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.init = void 0;
 const client = require("prom-client");
 function init(opts) {
-    const { interval = 60000, promClient = client } = opts;
+    const { interval = 60000, promClient = client, useGlobal = false } = opts;
     const QUEUE_NAME_LABEL = 'queue_name';
     const QUEUE_PREFIX_LABEL = 'queue_prefix';
     const activeMetricName = 'jobs_active_total';
@@ -50,13 +59,25 @@ function init(opts) {
             [QUEUE_NAME_LABEL]: queue.name,
             [QUEUE_PREFIX_LABEL]: keyPrefix,
         };
-        queue.on('completed', (job) => {
-            if (!job.finishedOn) {
-                return;
-            }
-            const duration = job.finishedOn - job.processedOn;
-            durationMetric.observe(labels, duration);
-        });
+        if (useGlobal) {
+            queue.on('global:completed', (jobId) => __awaiter(this, void 0, void 0, function* () {
+                const job = yield queue.getJob(jobId);
+                if (!job.finishedOn) {
+                    return;
+                }
+                const duration = job.finishedOn - job.processedOn;
+                durationMetric.observe(labels, duration);
+            }));
+        }
+        else {
+            queue.on('completed', (job) => {
+                if (!job.finishedOn) {
+                    return;
+                }
+                const duration = job.finishedOn - job.processedOn;
+                durationMetric.observe(labels, duration);
+            });
+        }
         const metricInterval = setInterval(() => {
             queue
                 .getJobCounts()

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,17 @@ export interface Options {
   useGlobal?: boolean;
 }
 
+export enum JobStatus {
+  COMPLETED = 'completed',
+  FAILED = 'failed'
+}
+
 export function init(opts: Options) {
   const { interval = 60000, promClient = client, useGlobal = false } = opts;
 
   const QUEUE_NAME_LABEL = 'queue_name';
   const QUEUE_PREFIX_LABEL = 'queue_prefix';
+  const STATUS_LABEL = 'status';
 
   const activeMetricName = 'jobs_active_total';
   const waitingMetricName = 'jobs_waiting_total';
@@ -19,6 +25,8 @@ export function init(opts: Options) {
   const failedMetricName = 'jobs_failed_total';
   const delayedMetricName = 'jobs_delayed_total';
   const durationMetricName = 'jobs_duration_milliseconds';
+  const waitingDurationMetricName = 'jobs_waiting_duration_milliseconds';
+  const attemptsMadeMetricName = 'jobs_attempts';
 
   const completedMetric = new promClient.Gauge({
     name: completedMetricName,
@@ -53,10 +61,45 @@ export function init(opts: Options) {
   const durationMetric = new promClient.Summary({
     name: durationMetricName,
     help: 'Time to complete jobs',
-    labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL],
+    labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL, STATUS_LABEL],
     maxAgeSeconds: 300,
     ageBuckets: 13,
   });
+
+  const waitingDurationMetric = new promClient.Summary({
+    name: waitingDurationMetricName,
+    help: 'Time spent waiting for a job to run',
+    labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL, STATUS_LABEL],
+    maxAgeSeconds: 300,
+    ageBuckets: 13
+  });
+
+  const attemptsMadeMetric = new promClient.Summary({
+    name: attemptsMadeMetricName,
+    help: 'Job attempts made',
+    labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL, STATUS_LABEL],
+    maxAgeSeconds: 300,
+    ageBuckets: 13
+  });
+
+  function recordJobMetrics(labels: {[key: string]: string}, status: JobStatus, job: bull.Job) {
+    if (!job.finishedOn) {
+      return;
+    }
+
+    const jobLabels = {
+      [STATUS_LABEL]: status,
+      ...labels
+    }
+
+    const jobDuration = job.finishedOn - job.processedOn!;
+    durationMetric.observe(jobLabels, jobDuration);
+
+    const waitingDuration = job.processedOn - job.timestamp;
+    waitingDurationMetric.observe(jobLabels, waitingDuration);
+
+    attemptsMadeMetric.observe(jobLabels, job.attemptsMade);
+  }
 
   function start(queue: bull.Queue) {
 
@@ -71,21 +114,19 @@ export function init(opts: Options) {
     if (useGlobal) {
       queue.on('global:completed', async (jobId: number) => {
         const job = await queue.getJob(jobId);
-
-        if (!job.finishedOn) {
-          return;
-        }
-        const duration = job.finishedOn - job.processedOn!;
-        durationMetric.observe(labels, duration);
+        recordJobMetrics(labels, JobStatus.COMPLETED, job);
       });
+      queue.on('global:failed', async (jobId: number) => {
+        const job = await queue.getJob(jobId);
+        recordJobMetrics(labels, JobStatus.FAILED, job)
+      })
     } else {
       queue.on('completed', (job) => {
-        if (!job.finishedOn) {
-          return;
-        }
-        const duration = job.finishedOn - job.processedOn!;
-        durationMetric.observe(labels, duration);
+        recordJobMetrics(labels, JobStatus.COMPLETED, job);
       });
+      queue.on('failed', (job) => {
+        recordJobMetrics(labels, JobStatus.FAILED, job)
+      })
     }
 
     const metricInterval = setInterval(() => {
@@ -107,6 +148,8 @@ export function init(opts: Options) {
       delayedMetric.remove(labels);
       activeMetric.remove(labels);
       waitingMetric.remove(labels);
+      waitingDurationMetric.remove(labels);
+      attemptsMadeMetric.remove(labels);
     }
     return {
       stop: () => clearInterval(metricInterval),


### PR DESCRIPTION
This library currently tracks queue metrics for all jobs in the queue, but the job duration is specific to which queue is processing the code. If we wanted to use this library to track job duration for a queue in a separate process (or on a separate server) we'd need to listen for the `global:completed` event. This method is very similar to the `completed` event except it is called with the `jobId` (which we can then pass to `queue.getJob`).

From: https://optimalbits.github.io/bull/

> Finally, you can just listen to events that happen in the queue. Listeners can be local, meaning that they only will receive notifications produced in the given queue instance, or global, meaning that they listen to all the events for a given queue. So you can attach a listener to any instance, even instances that are acting as consumers or producers. But note that a local event will never fire if the queue is not a consumer or producer, you will need to use global events in that case.

This also includes the addition of the following additional metrics changes:
- `jobs_duration_milliseconds` - added `status` label
- `jobs_waiting_duration_milliseconds` - added metric to track how long a job waits before getting started
- `jobs_attempts` - added metric to include how many job attempts were made before job completed/failed


