### PR TITLE
feat: Get the existing metric if it was created before

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Returns a queue metrics object which includes the following methods:
 * **@robbiet480**
 * **@TotallyNotElite**
 * **@ejhayes**
+* **@aagregorio**
 
 ## License
 MIT © [Pawel Badenski](https://github.com/pbadenski)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import client = require('prom-client');
 import * as bull from 'bull';
+import { getOrCreateMetric, Metrics } from './utils';
 
 export interface Options {
   promClient?: typeof client;
@@ -28,59 +29,59 @@ export function init(opts: Options) {
   const waitingDurationMetricName = 'jobs_waiting_duration_milliseconds';
   const attemptsMadeMetricName = 'jobs_attempts';
 
-  const completedMetric = new promClient.Gauge({
+  const completedMetric = getOrCreateMetric(Metrics.Gauge, {
     name: completedMetricName,
     help: 'Number of completed jobs',
     labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL],
-  });
+  }) as client.Gauge<string>;
 
-  const failedMetric = new promClient.Gauge({
+  const failedMetric = getOrCreateMetric(Metrics.Gauge, {
     name: failedMetricName,
     help: 'Number of failed jobs',
     labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL],
-  });
+  }) as client.Gauge<string>;
 
-  const delayedMetric = new promClient.Gauge({
+  const delayedMetric = getOrCreateMetric(Metrics.Gauge, {
     name: delayedMetricName,
     help: 'Number of delayed jobs',
     labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL],
-  });
+  }) as client.Gauge<string>;
 
-  const activeMetric = new promClient.Gauge({
+  const activeMetric = getOrCreateMetric(Metrics.Gauge, {
     name: activeMetricName,
     help: 'Number of active jobs',
     labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL],
-  });
+  }) as client.Gauge<string>;
 
-  const waitingMetric = new promClient.Gauge({
+  const waitingMetric = getOrCreateMetric(Metrics.Gauge, {
     name: waitingMetricName,
     help: 'Number of waiting jobs',
     labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL],
-  });
+  })as client.Gauge<string>;
 
-  const durationMetric = new promClient.Summary({
+  const durationMetric = getOrCreateMetric(Metrics.Summary, {
     name: durationMetricName,
     help: 'Time to complete jobs',
     labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL, STATUS_LABEL],
     maxAgeSeconds: 300,
     ageBuckets: 13,
-  });
+  }) as client.Summary<string>;
 
-  const waitingDurationMetric = new promClient.Summary({
+  const waitingDurationMetric = getOrCreateMetric(Metrics.Summary, {
     name: waitingDurationMetricName,
     help: 'Time spent waiting for a job to run',
     labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL, STATUS_LABEL],
     maxAgeSeconds: 300,
     ageBuckets: 13
-  });
+  }) as client.Summary<string>;
 
-  const attemptsMadeMetric = new promClient.Summary({
+  const attemptsMadeMetric = getOrCreateMetric(Metrics.Summary, {
     name: attemptsMadeMetricName,
     help: 'Job attempts made',
     labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL, STATUS_LABEL],
     maxAgeSeconds: 300,
     ageBuckets: 13
-  });
+  }) as client.Summary<string>;
 
   function recordJobMetrics(labels: {[key: string]: string}, status: JobStatus, job: bull.Job) {
     if (!job.finishedOn) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,50 @@
+import * as client from "prom-client";
+
+/**
+ * @internal
+ */
+export enum Metrics {
+    Gauge = "Gauge",
+    Summary = "Summary",
+    Histogram = "Histogram",
+    Counter = "Counter"
+};
+
+/**
+ * @internal
+ */
+export type Options =
+  | client.GaugeConfiguration<string>
+  | client.SummaryConfiguration<string>
+  | client.CounterConfiguration<string>
+  | client.HistogramConfiguration<string>;
+
+/**
+ * @internal
+ */
+export function getOrCreateMetric<T>(
+  type: Metrics,
+  options: Options,
+): client.Metric<string> {
+  const existingMetric = client.register.getSingleMetric(options.name);
+
+  if (existingMetric) {
+    return existingMetric;
+  }
+
+  switch (type) {
+    case "Gauge":
+      return new client.Gauge(options as client.GaugeConfiguration<string>);
+    case "Counter":
+      return new client.Counter(options as client.CounterConfiguration<string>);
+    case "Histogram":
+      return new client.Histogram(
+        options as client.HistogramConfiguration<string>,
+      );
+    case "Summary":
+      return new client.Summary(options as client.SummaryConfiguration<string>);
+    default:
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      throw new Error(`Unknown type: ${type}`);
+  }
+}


### PR DESCRIPTION
If for some reason you try to initialize the metrics and they already exist, the prom-client throws an exception.
This proposal is intended to prevent this by checking to see if the metric already exists before attempting to create it.
