### PR TITLE
fix: #17 fix crash of bull-prom when job is null.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,11 +95,15 @@ function init(opts) {
         if (useGlobal) {
             queue.on('global:completed', (jobId) => __awaiter(this, void 0, void 0, function* () {
                 const job = yield queue.getJob(jobId);
-                recordJobMetrics(labels, JobStatus.COMPLETED, job);
+                if (job) {
+                    recordJobMetrics(labels, JobStatus.COMPLETED, job);
+                }
             }));
             queue.on('global:failed', (jobId) => __awaiter(this, void 0, void 0, function* () {
                 const job = yield queue.getJob(jobId);
-                recordJobMetrics(labels, JobStatus.FAILED, job);
+                if (job) {
+                    recordJobMetrics(labels, JobStatus.FAILED, job);
+                }
             }));
         }
         else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,11 +114,15 @@ export function init(opts: Options) {
     if (useGlobal) {
       queue.on('global:completed', async (jobId: number) => {
         const job = await queue.getJob(jobId);
-        recordJobMetrics(labels, JobStatus.COMPLETED, job);
+        if (job) {
+          recordJobMetrics(labels, JobStatus.COMPLETED, job);
+        }
       });
       queue.on('global:failed', async (jobId: number) => {
         const job = await queue.getJob(jobId);
-        recordJobMetrics(labels, JobStatus.FAILED, job)
+        if (job) {
+          recordJobMetrics(labels, JobStatus.FAILED, job)
+        }
       })
     } else {
       queue.on('completed', (job) => {


### PR DESCRIPTION
Hi

I propose you a pull request to fix bug #17 that i have when observing global metrics:

```
[api] TypeError: Cannot read properties of null (reading 'finishedOn')
[api]     at recordJobMetrics (/home/phoenix/Developpement/Shadoware.Org/Software/woodstock-backup/nestjs/node_modules/bull-prom/lib/index.js:79:18)
[api]     at Object.<anonymous> (/home/phoenix/Developpement/Shadoware.Org/Software/woodstock-backup/nestjs/node_modules/bull-prom/lib/index.js:98:17)
[api]     at Generator.next (<anonymous>)
[api]     at fulfilled (/home/phoenix/Developpement/Shadoware.Org/Software/woodstock-backup/nestjs/node_modules/bull-prom/lib/index.js:5:58)
[api]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
```
