### PR TITLE
Start tracking paused jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Provides [Prometheus](https://prometheus.io/) metrics for [Bull](https://github.
 | jobs_delayed_total                  | counter | Total number of jobs that will run in the future        |
 | jobs_failed_total                   | counter | Total number of failed jobs                             |
 | jobs_waiting_total                  | counter | Total number of jobs waiting to be processed            |
+| jobs_paused_total                   | counter | Total number of paused jobs                             |
 | jobs_duration_milliseconds          | summary | Processing time for completed/failed                    |
 | jobs_waiting_duration_milliseconds  | summary | Waiting time for completed/failed                       |
 | jobs_attempts                       | summary | Processing time for completed/failed/jobs               |

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ function init(opts) {
     const STATUS_LABEL = 'status';
     const activeMetricName = 'jobs_active_total';
     const waitingMetricName = 'jobs_waiting_total';
+    const pausedMetricName = 'jobs_paused_total';
     const completedMetricName = 'jobs_completed_total';
     const failedMetricName = 'jobs_failed_total';
     const delayedMetricName = 'jobs_delayed_total';
@@ -52,6 +53,11 @@ function init(opts) {
     const waitingMetric = new promClient.Gauge({
         name: waitingMetricName,
         help: 'Number of waiting jobs',
+        labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL],
+    });
+    const pausedMetric = new promClient.Gauge({
+        name: pausedMetricName,
+        help: 'Number of paused jobs',
         labelNames: [QUEUE_NAME_LABEL, QUEUE_PREFIX_LABEL],
     });
     const durationMetric = new promClient.Summary({
@@ -113,12 +119,13 @@ function init(opts) {
         const metricInterval = setInterval(() => {
             queue
                 .getJobCounts()
-                .then(({ completed, failed, delayed, active, waiting }) => {
+                .then(({ completed, failed, delayed, active, waiting, paused }) => {
                 completedMetric.set(labels, (completed || 0));
                 failedMetric.set(labels, (failed || 0));
                 delayedMetric.set(labels, (delayed || 0));
                 activeMetric.set(labels, (active || 0));
                 waitingMetric.set(labels, (waiting || 0));
+                pausedMetric.set(labels, (paused || 0));
             });
         }, interval);
         const removeMetrics = () => {
@@ -128,6 +135,7 @@ function init(opts) {
             delayedMetric.remove(labels);
             activeMetric.remove(labels);
             waitingMetric.remove(labels);
+            pausedMetric.remove(labels);
             waitingDurationMetric.remove(labels);
             attemptsMadeMetric.remove(labels);
         };


### PR DESCRIPTION
Start tracking paused jobs:
* Create a gauge for tracking paused jobs
* Set the value in the callback of `getJobCounts`